### PR TITLE
Fixed changed log syntax to support PyPI packaging.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,13 @@ Changes
 Unreleased
 ----------
 
+3.10.1 (2025-06-20)
+-------------------
+
+- Fixed changelog syntax to support PyPI packaging.
 
 3.10.0 (2025-06-20)
-------------------
+-------------------
 
 - Tests are no longer bundled in released wheels (gh-1478)
 - Move repository to the Django Commons organization (gh-1391)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Unreleased
 3.10.1 (2025-06-20)
 -------------------
 
-- Fixed changelog syntax to support PyPI packaging.
+- Fixed changelog syntax to support PyPI packaging (gh-1499)
 
 3.10.0 (2025-06-20)
 -------------------


### PR DESCRIPTION
This resolves the packaging problem for 3.10.0 https://github.com/django-commons/django-simple-history/actions/runs/15783383565/job/44497104163


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
